### PR TITLE
Add esm build and package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,14 @@
   "homepage": "https://gillchristian.github.io/remote-data-ts",
   "version": "2.1.0",
   "main": "dist/index.js",
+  "module": "dist/_esm/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    "types": "./dist/index.d.ts",
+    "node": "./dist/index.js",
+    "import": "./dist/_esm/index.js",
+    "require": "./dist/index.js"
+  },
   "sideEffects": false,
   "repository": {
     "type": "git",
@@ -22,7 +29,9 @@
     "fp-ts": "^2.11.8"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build:cjs": "tsc -p tsconfig.build.json",
+    "build:esm": "tsc -p tsconfig.build.esm.json",
+    "build": "yarn build:cjs && yarn build:esm",
     "watch": "tsc -w --noEmit",
     "prerelease": "yarn build",
     "fmt": "prettier  --write '**/*.{ts,json,md}'",

--- a/tsconfig.build.esm.json
+++ b/tsconfig.build.esm.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.settings.json",
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "ES2015",
+    "moduleResolution": "node",
+    "declaration": false,
+    "outDir": "./dist/_esm",
+    "rootDirs": [],
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
We noticed that `remote-data-ts` only exposed a common-js version which was problematic for a few reasons, notably: it prevented tree-shaking for fp-ts.  This PR adds a `tsconfig.build.esm.json` with `module: ES2015` and `target: ES6` and builds it to an `_esm` directory.  Additionally it adds an `exports` field to the package json which points typescript, node, bundlers, and browsers to the right places.